### PR TITLE
Fix unsafe history_id parsing in Kernel chat abort route

### DIFF
--- a/src/kernel/src/kuwa/kernel/routes/chat.py
+++ b/src/kernel/src/kuwa/kernel/routes/chat.py
@@ -1,9 +1,50 @@
+import json
 import requests
 from typing import List, Optional
 from flask import Blueprint, request, Response
 from ..variable import *
 from ..safety_middleware import safety_middleware
 chat = Blueprint('chat', __name__)
+
+
+def parse_history_id(raw_history_id) -> Optional[int]:
+    if isinstance(raw_history_id, bool):
+        return None
+
+    if isinstance(raw_history_id, int):
+        return raw_history_id
+
+    if isinstance(raw_history_id, str):
+        try:
+            return int(raw_history_id)
+        except ValueError:
+            return None
+
+    return None
+
+
+def parse_history_ids(raw_history_id: str) -> Optional[List[int]]:
+    """Parse a history_id form value without executing attacker-controlled code."""
+    try:
+        parsed = json.loads(raw_history_id)
+    except (TypeError, json.JSONDecodeError):
+        parsed = raw_history_id
+
+    history_id = parse_history_id(parsed)
+    if history_id is not None:
+        return [history_id]
+
+    if isinstance(parsed, list):
+        history_ids = []
+        for item in parsed:
+            history_id = parse_history_id(item)
+            if history_id is None:
+                return None
+            history_ids.append(history_id)
+        return history_ids
+
+    return None
+
 
 @chat.route("/completions", methods=["POST"])
 def completions():
@@ -65,9 +106,11 @@ def completions_backend(form: dict, headers: dict, dest:list):
 def abort():
     history_id, user_id = request.form.get("history_id"), request.form.get("user_id")
     if history_id and user_id:
-        history_id = eval(history_id)
+        history_ids = parse_history_ids(history_id)
+        if history_ids is None:
+            return "Invalid history_id", 400
         for i, o in data.items():
-            dest = [k for k in o if int(k[2]) in history_id and k[3] == user_id]
+            dest = [k for k in o if int(k[2]) in history_ids and k[3] == user_id]
             for d in dest:
                 requests.get(d[0] + "/abort", timeout=10)
     return "Success"

--- a/src/kernel/test/test_chat_abort.py
+++ b/src/kernel/test/test_chat_abort.py
@@ -1,0 +1,86 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from flask import Flask
+
+from kuwa.kernel.routes import chat as chat_module
+from kuwa.kernel.routes.chat import chat, parse_history_ids
+
+
+class TestParseHistoryIds(unittest.TestCase):
+    def test_accepts_json_list(self):
+        self.assertEqual(parse_history_ids("[1, 2, 3]"), [1, 2, 3])
+
+    def test_accepts_single_history_id(self):
+        self.assertEqual(parse_history_ids("1"), [1])
+
+    def test_accepts_json_string_history_id(self):
+        self.assertEqual(parse_history_ids('"1"'), [1])
+
+    def test_rejects_non_integer_values(self):
+        self.assertIsNone(parse_history_ids('{"id": 1}'))
+        self.assertIsNone(parse_history_ids("1.5"))
+        self.assertIsNone(parse_history_ids("[1, 1.5]"))
+        self.assertIsNone(parse_history_ids("not-a-history-id"))
+
+    def test_rejects_booleans(self):
+        self.assertIsNone(parse_history_ids("true"))
+        self.assertIsNone(parse_history_ids("[1, false]"))
+
+
+class TestAbortRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.register_blueprint(chat)
+        self.client = self.app.test_client()
+        self.original_data = dict(chat_module.data)
+        chat_module.data.clear()
+
+    def tearDown(self):
+        chat_module.data.clear()
+        chat_module.data.update(self.original_data)
+
+    def test_abort_forwards_valid_history_ids(self):
+        chat_module.data["test-model"] = [
+            ["http://executor.example", "BUSY", "123", "test-user"],
+            ["http://other.example", "BUSY", "456", "other-user"],
+        ]
+
+        with patch.object(chat_module.requests, "get") as mock_get:
+            response = self.client.post(
+                "/abort",
+                data={
+                    "history_id": "[123]",
+                    "user_id": "test-user",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, b"Success")
+        mock_get.assert_called_once_with("http://executor.example/abort", timeout=10)
+
+    def test_abort_rejects_eval_payload_without_side_effects(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            marker = Path(tmpdir) / "eval_marker"
+            payload = (
+                f'(__import__("pathlib").Path("{marker}").write_text("executed"), '
+                "[])[1]"
+            )
+
+            response = self.client.post(
+                "/abort",
+                data={
+                    "history_id": payload,
+                    "user_id": "test-user",
+                },
+            )
+
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.data, b"Invalid history_id")
+            self.assertFalse(marker.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary / 摘要

This PR removes unsafe `eval()` usage from the Kernel `/chat/abort` route.

此 PR 移除 Kernel `/chat/abort` 路由中不安全的 `eval()` 使用。

## Changes / 變更內容

- Parse `history_id` as a JSON list of integers or a single integer value.
- Reject invalid `history_id` values with HTTP 400.
- Add regression tests to ensure invalid payloads are rejected without side effects.
- Preserve existing behavior for valid abort requests.

---

- 將 `history_id` 解析為整數 JSON 陣列，或單一整數值。
- 對不合法的 `history_id` 回傳 HTTP 400。
- 新增 regression tests，確認不合法 payload 會被拒絕且不產生副作用。
- 保留合法 abort request 的既有行為。

## Test / 測試

```bash
PYTHONPATH=src/kernel/src python3 -m unittest discover -s src/kernel/test -v
```

Result / 結果：

```text
Ran 7 tests

OK
```
